### PR TITLE
fix: remove table of contents instruction from License block

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -37,7 +37,6 @@ See [Contributors](https://github.com/qctrl/[REPOSITORY]/graphs/contributors).
 - If **Unlicensed:**
   - Delete `LICENSE`.
   - Delete `LICENSE-commercial`.
-  - Delete the "License" item in the [Table of contents](#table-of-contents).
   - Delete this entire [License](#license) section.
 - **DELETE THIS LIST**.
 


### PR DESCRIPTION
Following the template I took ~30 seconds looking for the table of contents until I realised we are not using them anymore. Let's save someone else a few seconds.