### PR TITLE
style: Remove requirement for command prompt

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -6,15 +6,15 @@ A good description is clear, short, and to the point. Describe the purpose of th
 
 Describe how to install the project locally then **DELETE THIS LINE**. For example:
 
-1. `$ git clone git@github.com:qctrl/[REPOSITORY].git`
-1. `$ cd [REPOSITORY]`
-1. `$ install...`
+1. `git clone git@github.com:qctrl/[REPOSITORY].git`
+1. `cd [REPOSITORY]`
+1. `install...`
 
 ## Usage
 
 Describe how to use the project after installation then **DELETE THIS LINE**. For example:
 
-1. `$ run...`
+1. `run...`
 
 ## Contributing
 


### PR DESCRIPTION
This PR removes the requirement to start command-line instructions with a command prompt (`$`). This will save some bytes and make copy/pasting command-line instructions easier.