### PR TITLE
Changing to code block of type shell to allow copying of code in Github

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -6,15 +6,19 @@ A good description is clear, short, and to the point. Describe the purpose of th
 
 Describe how to install the project locally then **DELETE THIS LINE**. For example:
 
-1. `git clone git@github.com:qctrl/[REPOSITORY].git`
-1. `cd [REPOSITORY]`
-1. `install...`
+```shell
+git clone git@github.com:qctrl/[REPOSITORY].git
+cd [REPOSITORY]
+install...
+```
 
 ## Usage
 
 Describe how to use the project after installation then **DELETE THIS LINE**. For example:
 
-1. `run...`
+```shell
+run...
+```
 
 ## Contributing
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Changing to code block of type `sh` to allow copying of code in Github
### Screenshots
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/6543171/186570433-c7656819-f61f-41b7-bbc4-547e3f7d5bf2.png">
<img width="1082" alt="image" src="https://user-images.githubusercontent.com/6543171/186570968-80c198b9-db16-4147-98f9-eccd49e8b01a.png">

