### PR TITLE
chore: Update instructions for Python version classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ keywords = [
     "qudit"
 ]
 
-# classifiers: Do not edit, unless the package only supports a subset of Pythpn versions.
+# classifiers: Do not edit, unless the package only supports a subset of Python versions.
 # In this case, remove unsupported versions from the classifiers.
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ keywords = [
 ]
 
 # classifiers: Do not edit, unless the package only supports a subset of Python versions.
-# In this case, remove unsupported versions from the classifiers.
+# In that case, remove unsupported versions from the classifiers.
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,8 @@ keywords = [
     "qudit"
 ]
 
-# classifiers: DO NOT EDIT
+# classifiers: Do not edit, unless the package only supports a subset of Pythpn versions.
+# In this case, remove unsupported versions from the classifiers.
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -85,6 +86,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Scientific/Engineering :: Visualization",


### PR DESCRIPTION
A suggestion of how we can deal with the Python versions in the classifiers.

Changes proposed in this pull request:
- Add all currently supportable Python versions to the list of classifiers in pyproject.toml.
- Add instructions to remove Python versions from the list of classifiers when they're not supported by a particular package.