### PR TITLE
chore: Add Fire Opal to list of keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "keywords": [
     "black opal",
     "boulder opal",
+    "fire opal",
     "nisq",
     "open controls",
     "q control",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ documentation = ""
 keywords = [
     "black opal",
     "boulder opal",
+    "fire opal",
     "nisq",
     "open controls",
     "q control",


### PR DESCRIPTION
Currently "Fire Opal" is the only product not in the list of keywords. It would probably make sense in the future to customize the list of keywords depending on the package, but for the moment we can at least make the current approach look up to date.

If this is approved, I'll go through the repos and update the keywords in them.

Changes proposed in this pull request:
- Add "fire opal" to the list of keywords in the `pyproject.toml` and `package.json`, for symmetry with other products.