### PR TITLE
feat: Add instructions to pyproject.toml about how to access the internal PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,13 +108,8 @@ Twitter = "https://twitter.com/qctrlHQ"
 YouTube = "https://www.youtube.com/qctrl"
 GitHub = "https://github.com/qctrl"
 
-# Add the package dependencies below this heading in the form 'package_name = "package_version"'.
-[tool.poetry.dependencies]
-
-# Remove the block below if the package is open source, or if the package is not
-# expected to use dependencies that are only available in the Internal PyPI
-# (such as development versions of packages).
-[[tool.poetry.source]]
-name = "Q-CTRL PyPI"
-url = "https://pypi.q-ctrl.com/simple"
-secondary = true
+# Uncomment the block below if the package requires access to the Internal PyPI.
+# [[tool.poetry.source]]
+# name = "Q-CTRL PyPI"
+# url = "https://pypi.q-ctrl.com/simple"
+# secondary = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,13 +108,13 @@ Twitter = "https://twitter.com/qctrlHQ"
 YouTube = "https://www.youtube.com/c/qctrl"
 GitHub = "https://github.com/qctrl"
 
+# Add the package dependencies below this heading in the form 'package_name = "package_version"'.
 [tool.poetry.dependencies]
-# Add the package dependencies here in the form 'package_name = "package_version"'.
 
 # Remove the block below if the package is open source, or if the package is not
 # expected to use dependencies that are only available the Internal PyPI
 # (such as development versions of packages).
 [[tool.poetry.source]]
-name = 'Q-CTRL PyPI'
-url = 'https://pypi.q-ctrl.com/simple'
+name = "Q-CTRL PyPI"
+url = "https://pypi.q-ctrl.com/simple"
 secondary = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ GitHub = "https://github.com/qctrl"
 [tool.poetry.dependencies]
 
 # Remove the block below if the package is open source, or if the package is not
-# expected to use dependencies that are only available the Internal PyPI
+# expected to use dependencies that are only available in the Internal PyPI
 # (such as development versions of packages).
 [[tool.poetry.source]]
 name = "Q-CTRL PyPI"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,3 +107,14 @@ Facebook = "https://www.facebook.com/qctrl"
 Twitter = "https://twitter.com/qctrlHQ"
 YouTube = "https://www.youtube.com/c/qctrl"
 GitHub = "https://github.com/qctrl"
+
+[tool.poetry.dependencies]
+# Add the package dependencies here in the form 'package_name = "package_version"'.
+
+# Remove the block below if the package is open source, or if the package is not
+# expected to use dependencies that are only available the Internal PyPI
+# (such as development versions of packages).
+[[tool.poetry.source]]
+name = 'Q-CTRL PyPI'
+url = 'https://pypi.q-ctrl.com/simple'
+secondary = true


### PR DESCRIPTION
Just an idea: I noticed that often the Internal PyPI is added to the `pyproject.toml` without specifying that this is a secondary PyPI. This creates a situation where packages such as `qctrl-commons` are fetched from the internal PyPI even if they're available in the public PyPI.

Some problems arise from this, such as Docker failing when run locally because `poetry.lock` requested packages from the internal PyPI when the local Docker doesn't have access to those. To avoid this problem, I added `secondary = true` to the internal PyPI entry in the `pyproject.toml` of the Visualizer. This seems to make the resulting `poetry.lock` better, requesting packages from the internal PyPI only when necessary, which makes the local build of Docker images work again.

I reckon the practice of putting the internal PyPI as secondary can benefit most repos, so that the Internal API is only hit when we really need. The idea here then would be to add this option in the template, so that every new package would set the internal PyPI as secondary by default.

I don't have too strong feelings about this though, so feel free to let me know if the idea is not helpful.

Changes proposed in this pull request:
- Add an entry to the `pyproject.toml` template explaining how to add the Internal PyPI to it.