### PR TITLE
fix: Update TOML file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,11 @@ readme = "README.md"
 # homepage: DO NOT EDIT
 homepage = "https://q-ctrl.com"
 
-# repository: A link to the public GitHub repository or "" if the repository is private
+# repository: A link to the public GitHub repository. Remove it if the repository is private.
 repository = "https://github.com/qctrl/template"
 
 # documentation: A link to the "User documentation" as defined in https://code.q-ctrl.com/documentation#user-documentation
+# Remove it if not needed.
 documentation = ""
 
 # keywords: DO NOT EDIT


### PR DESCRIPTION
Poetry core (poetry-core 1.6+) is now stricter about the type of each field in the TOML file (see the configuration [here](https://github.com/python-poetry/poetry-core/blob/main/src/poetry/core/json/schemas/poetry-schema.json)). The `repository` and `documentation` field now must be a valid link. Any empty string would cause an intallation error when we try to install the package with `pip`.