### PR TITLE
chore: Update template to use mknotebooks instead

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,6 @@ To serve your site from the [`gh-pages`](https://docs.github.com/en/pages/gettin
 
 ### Plugins to consider
 
-- [docstrings](https://mkdocstrings.github.io/)
-- [mkdocs-jupyter/](https://pypi.org/project/mkdocs-jupyter/)
+- [mkdocstrings](https://mkdocstrings.github.io/)
+- [mknotebooks](https://github.com/greenape/mknotebooks)
 - [mike](https://pypi.org/project/mike/)


### PR DESCRIPTION
Addresses: https://qctrl.atlassian.net/browse/(ticket)

Changes proposed in this pull request:

- Update template to use mknotebooks instead

Notes
- See discussion https://github.com/qctrl/code/pull/146#discussion_r2400352957.
